### PR TITLE
Fix license

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git://github.com/elasticsearch/bower-elasticsearch-js.git"
   },
   "author": "Spencer Alger <spencer@spenceralger.com>",
-  "license": "Apache 2.0",
+  "license": "Apache License 2.0",
   "bugs": {
     "url": "https://github.com/elasticsearch/bower-elasticsearch-js/issues"
   },


### PR DESCRIPTION
When trying to upgrade the `license-checker` dep in Kibana (https://github.com/elastic/kibana/pull/14351), it failed because it expects `Apache license` to be present, see https://github.com/davglass/license-checker/blob/de9710b0ed7a17265e352a23e66bcc96eba956c7/lib/license.js#L13.